### PR TITLE
Replace tape tests with node test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "install": "node-gyp-build",
-    "test": "standard && tape test.js",
+    "test": "standard && node --test test.js",
     "prebuild": "prebuildify --napi --strip",
     "fetch-deps": "git submodule update --recursive --init",
     "build-transmission": "./deps/build-transmission.sh"
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "prebuildify": "^5.0.1",
-    "standard": "^17.0.0",
-    "tape": "^5.6.3"
+    "standard": "^17.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,67 @@
-const tape = require('tape')
-const Transmission = require('./index')
 const os = require('os')
-const path = require('path')
 const fs = require('fs')
+const path = require('path')
+const assert = require('node:assert/strict')
+const { describe, before, beforeEach, afterEach, it } = require('node:test')
+
+const Transmission = require('./index')
 
 const tmpDir = path.join(os.tmpdir(), 'transmission-native')
+const APP_NAME = 'transmission'
+
+describe('transmission-native tests', async () => {
+  let tr
+
+  before(() => removeTmpDir()) // In case tmp folder already exist)
+
+  beforeEach(() => {
+    tr = new Transmission(tmpDir, APP_NAME)
+  })
+
+  afterEach(() => {
+    tr.close()
+    removeTmpDir()
+  })
+
+  it('request should succeed with callback', (done) => {
+    const req = { method: 'session-get' }
+
+    tr.request(req, (err, json) => {
+      if (err) done(err)
+      assert.equal(json.result, 'success')
+      done()
+    })
+  })
+
+  it('request should succeed with promise', async () => {
+    const req = { method: 'session-get' }
+    const json = await tr.request(req)
+
+    assert.equal(json.result, 'success')
+  })
+
+  it('request should return error', async () => {
+    const req = { method: 'unknown' }
+
+    await assert.rejects(tr.request(req), { message: 'method name not recognized' })
+  })
+
+  it('one async request', async () => {
+    const req = { method: 'port-test' }
+    const json = await tr.request(req)
+
+    assert.equal(json.result, 'success')
+  })
+
+  it('two async requests', async () => {
+    const req = { method: 'port-test' }
+    const promises = [tr.request(req), tr.request(req)]
+    const results = await Promise.all(promises)
+
+    assert.equal(results[0].result, 'success')
+    assert.equal(results[1].result, 'success')
+  })
+})
 
 const removeTmpDir = () => {
   if (fs.existsSync(tmpDir)) {
@@ -12,71 +69,3 @@ const removeTmpDir = () => {
     fs.rmSync(tmpDir, { recursive: true })
   }
 }
-
-let tr
-
-tape('setup', (t) => {
-  removeTmpDir() // In case tmp folder already exist
-  tr = new Transmission(tmpDir, 'transmission')
-  t.end()
-})
-
-tape('request should succeed', t => {
-  const req = { method: 'session-get' }
-  tr.request(req, (err, json) => {
-    t.error(err)
-    t.equal(json.result, 'success')
-    t.end()
-  })
-})
-
-tape('request should succeed with promise api', async (t) => {
-  const req = { method: 'session-get' }
-  const json = await tr.request(req)
-  t.equal(json.result, 'success')
-  t.end()
-})
-
-tape('request should return error', t => {
-  const req = { method: 'unknown' }
-  tr.request(req, (err, res) => {
-    t.equal(err.message, 'method name not recognized')
-    t.end()
-  })
-})
-
-tape('one async request', t => {
-  const req = { method: 'port-test' }
-  tr.request(req, (err, res) => {
-    t.error(err)
-    t.ok(res)
-    t.end()
-  })
-})
-
-tape('two async requests', t => {
-  t.plan(4)
-  let count = 0
-  const req = { method: 'port-test' }
-
-  for (let i = 0; i < 2; i++) {
-    tr.request(req, (err, res) => {
-      t.error(err)
-      t.ok(res)
-      if (++count === 2) t.end()
-    })
-  }
-})
-
-tape('sessionClose', t => {
-  tr.close()
-  t.pass('did not crash')
-  t.end()
-})
-
-tape('teardown', (t) => {
-  removeTmpDir()
-  t.end()
-})
-
-tape.onFailure(removeTmpDir)

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const os = require('os')
 const fs = require('fs')
-const path = require('path')
+const path = require('node:path')
 const assert = require('node:assert/strict')
 const { describe, before, beforeEach, afterEach, it } = require('node:test')
 

--- a/test.js
+++ b/test.js
@@ -65,7 +65,7 @@ describe('transmission-native tests', async () => {
 
 const removeTmpDir = () => {
   if (fs.existsSync(tmpDir)) {
-    console.log('🗑️ Removing tmp folder...')
+    console.log('Removing tmp folder...')
     fs.rmSync(tmpDir, { recursive: true })
   }
 }


### PR DESCRIPTION
- Removed `tape`
- Rewrote tests with NodeJS test runner, using `describe`/`it` syntax.
- Removed dependencies between tests by instantiating/closing transmission instance `beforeEach`/`afterEach`.
Closes #6 