### PR TITLE
Revert "Remove tr_formatter calls"

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -10,6 +10,24 @@
 #include "deps/transmission/libtransmission/utils.h"
 #include "deps/transmission/libtransmission/variant.h"
 
+#define MEM_K 1024
+#define MEM_K_STR "KiB"
+#define MEM_M_STR "MiB"
+#define MEM_G_STR "GiB"
+#define MEM_T_STR "TiB"
+
+#define DISK_K 1000
+#define DISK_K_STR "kB"
+#define DISK_M_STR "MB"
+#define DISK_G_STR "GB"
+#define DISK_T_STR "TB"
+
+#define SPEED_K 1000
+#define SPEED_K_STR "kB/s"
+#define SPEED_M_STR "MB/s"
+#define SPEED_G_STR "GB/s"
+#define SPEED_T_STR "TB/s"
+
 typedef struct {
   uv_mutex_t _mutex;
   uv_cond_t _cond;
@@ -100,6 +118,10 @@ NAPI_METHOD(sessionInit) {
   strcpy(appName, appNameBuffer);
 
   tr_variant settings;
+
+  tr_formatter_mem_init(MEM_K, MEM_K_STR, MEM_M_STR, MEM_G_STR, MEM_T_STR);
+  tr_formatter_size_init(DISK_K, DISK_K_STR, DISK_M_STR, DISK_G_STR, DISK_T_STR);
+  tr_formatter_speed_init(SPEED_K, SPEED_K_STR, SPEED_M_STR, SPEED_G_STR, SPEED_T_STR);
 
   tr_variantInitDict(&settings, 0);
   tr_sessionLoadSettings(&settings, configDir, appName);


### PR DESCRIPTION
I previously removed the calls to these init functions as I thought sane default values would be initialized already.
As a result, I always get a value for `rateDownload` of `0` for instance.

These functions initialize the `units` object returned in a RPC `session-get` request.
Unfortunately, the `units` object can't be changed with a `session-set` request, despite what the docs could let us think, as the `units` property is not listed as an immutable property [here](https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#411-mutators).