### PR TITLE
Return errors as json responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,8 @@ class Transmission {
     tr.request(self, Buffer.from(JSON.stringify(reqJson)), (err, res) => {
       if (err) return cb(err)
       const resJson = JSON.parse(res)
-      const e = (resJson.result !== 'success') ? new Error(resJson.result) : null
       this.set.delete(self)
-      cb(e, resJson)
+      cb(null, resJson)
     })
   }
 }

--- a/test.js
+++ b/test.js
@@ -44,8 +44,8 @@ describe('transmission-native tests', async () => {
 
   it('request should return error', async () => {
     const req = { method: 'unknown' }
-
-    await assert.rejects(tr.request(req), { message: 'method name not recognized' })
+    const res = await tr.request(req)
+    assert.equal(res.result, 'method name not recognized')
   })
 
   it('one async request', async () => {


### PR DESCRIPTION
See #18.
Due to a discussion with @tony-go :100: 
This would align with the behavior of https://github.com/G-Ray/react-native-transmission.