### PR TITLE
Windows add mt flags + use forked transmission

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,9 +5,7 @@ name: Build, test, and upload prebuilds
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/transmission"]
 	path = deps/transmission
-	url = https://github.com/transmission/transmission.git
+	url = https://github.com/G-Ray/transmission.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,11 +23,6 @@
         ],
       }],
       ['OS=="win"', {
-        'msvs_settings': {
-          'VCLinkerTool': {
-            'AdditionalOptions': [ '/NODEFAULTLIB:LIBCMT' ],
-          },
-        },
         "libraries": [
           "<(module_root_dir)/deps/transmission/build/libtransmission/Release/transmission.lib",
           "<(module_root_dir)/deps/transmission/build/third-party/dht.bld/pfx/lib/dht.lib",
@@ -43,9 +38,9 @@
           "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/libcurl.lib",
           "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/libcrypto.lib",
           "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/libssl.lib",
-          "-lws2_32.lib",
-          "-lCrypt32.lib",
-          "-lIphlpapi.lib"
+          "ws2_32.lib",
+          "Crypt32.lib",
+          "Iphlpapi.lib",
         ]
       }],
     ],

--- a/scripts/build-transmission.js
+++ b/scripts/build-transmission.js
@@ -71,6 +71,8 @@ const build = async () => {
       `-DCURL_INCLUDE_DIR=${VCPKG_INSTALLATION_ROOT}\\packages/curl_x64-windows-static/include`,
       `-DCURL_LIBRARY=${VCPKG_INSTALLATION_ROOT}\\packages/curl_x64-windows-static/lib`,
       // Use static version of the run-time library
+      '-DCMAKE_C_FLAGS=/MT',
+      '-DCMAKE_CXX_FLAGS=/MT',
       '-DCMAKE_C_FLAGS_RELEASE=/MT',
       '-DCMAKE_CXX_FLAGS_RELEASE=/MT'
     ]


### PR DESCRIPTION
- Compile for windows with `/MT` flag
- Use a transmission fork to fix possible crash on windows when there is no file handler to write logs (like stdout/stderr)