### PR TITLE
Fix zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ vcpkg install openssl --triplet=x64-windows
 ```sh
 npm run fetch-deps
 # For Windows you need to set VCPKG_INSTALLATION_ROOT env variable
+# $Env:VCPKG_INSTALLATION_ROOT="PATH_TO_VCPKG"
 npm run build-transmission
 npm install
 npm test # optional

--- a/binding.gyp
+++ b/binding.gyp
@@ -36,6 +36,7 @@
           "<(module_root_dir)/deps/transmission/build/third-party/miniupnpc.bld/pfx/lib/miniupnpc.lib",
           "<(module_root_dir)/deps/transmission/build/third-party/wildmat/Release/wildmat.lib",
           "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/libcurl.lib",
+          "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/zlib.lib",
           "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/libcrypto.lib",
           "$(VCPKG_INSTALLATION_ROOT)/installed/x64-windows-static/lib/libssl.lib",
           "ws2_32.lib",

--- a/scripts/build-transmission.js
+++ b/scripts/build-transmission.js
@@ -72,10 +72,10 @@ const build = async () => {
       `-DCURL_LIBRARY=${VCPKG_INSTALLATION_ROOT}/packages/curl_x64-windows-static/lib/libcurl.lib`,
       `-DOPENSSL_ROOT_DIR=${VCPKG_INSTALLATION_ROOT}/packages/openssl_x64-windows-static`,
       // Use static version of the run-time library
-      '-DCMAKE_C_FLAGS=/MT',
-      '-DCMAKE_CXX_FLAGS=/MT',
-      '-DCMAKE_C_FLAGS_RELEASE=/MT',
-      '-DCMAKE_CXX_FLAGS_RELEASE=/MT'
+      '-DCMAKE_C_FLAGS=/MT /MP',
+      '-DCMAKE_CXX_FLAGS=/MT /MP',
+      '-DCMAKE_C_FLAGS_RELEASE=/MT /MP',
+      '-DCMAKE_CXX_FLAGS_RELEASE=/MT /MP'
     ]
 
     await cmake([...flags, '..'], { cwd: buildPath, env })

--- a/scripts/build-transmission.js
+++ b/scripts/build-transmission.js
@@ -66,10 +66,11 @@ const build = async () => {
     const flags = [
       ...COMMON_CMAKE_FLAGS,
       // Set vcpkg toolchain file path
-      `-DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}\\scripts\\buildsystems\\vcpkg.cmake`,
+      `-DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake`,
       // Set include and lib dir paths to static libcurl
-      `-DCURL_INCLUDE_DIR=${VCPKG_INSTALLATION_ROOT}\\packages/curl_x64-windows-static/include`,
-      `-DCURL_LIBRARY=${VCPKG_INSTALLATION_ROOT}\\packages/curl_x64-windows-static/lib`,
+      `-DCURL_INCLUDE_DIR=${VCPKG_INSTALLATION_ROOT}/packages/curl_x64-windows-static/include`,
+      `-DCURL_LIBRARY=${VCPKG_INSTALLATION_ROOT}/packages/curl_x64-windows-static/lib/libcurl.lib`,
+      `-DOPENSSL_ROOT_DIR=${VCPKG_INSTALLATION_ROOT}/packages/openssl_x64-windows-static`,
       // Use static version of the run-time library
       '-DCMAKE_C_FLAGS=/MT',
       '-DCMAKE_CXX_FLAGS=/MT',


### PR DESCRIPTION
On Windows the addon worked with nodejs, as node exports zlib symbols, but not with `electron` as they are not exported.

We should definitely link with the static `zlib.lib`.

I guess this is the reason of https://github.com/G-Ray/pikatorrent/issues/49