### PR TITLE
Enable macos 1

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install linux deps
       run: sudo apt update && sudo apt install -y libcurl4-openssl-dev
       if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Install macos deps
+      run: sudo -H pip install setuptools
+      if: ${{ matrix.os == 'macos-latest' }}
     - name: Install windows deps
       run: vcpkg install curl openssl --triplet=x64-windows-static
       if: ${{ matrix.os == 'windows-latest' }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
       "<!(node -e \"require('napi-macros')\")",
     ],
     "conditions": [
-      ['OS=="linux"', {
+      ['OS in "linux mac"', {
         "libraries": [
           "<(module_root_dir)/deps/transmission/build/libtransmission/libtransmission.a",
           "<(module_root_dir)/deps/transmission/build/third-party/dht.bld/pfx/lib/libdht.a",

--- a/scripts/build-transmission.js
+++ b/scripts/build-transmission.js
@@ -2,7 +2,7 @@
 const os = require('node:os')
 const fs = require('node:fs')
 const path = require('node:path')
-const { spawn, execSync } = require('node:child_process')
+const { spawn } = require('node:child_process')
 
 const NPROCESSORS = os.availableParallelism()
 const COMMON_CMAKE_FLAGS = [
@@ -85,13 +85,9 @@ const build = async () => {
     }
       break
     case 'Darwin': {
-      const OPENSSL_ROOT_DIR = execSync(
-        'brew --prefix openssl',
-        { encoding: 'utf8' }).trim()
       const flags = [
         ...COMMON_CMAKE_FLAGS,
-        '-DRUN_CLANG_TIDY=OFF',
-        '-DOPENSSL_ROOT_DIR=' + OPENSSL_ROOT_DIR
+        '-DRUN_CLANG_TIDY=OFF'
       ]
 
       await cmake([...flags, '..'], { cwd: buildPath, env })


### PR DESCRIPTION
- Openssl libs seems to be found just fine in CI so I removed `DOPENSSL_ROOT_DIR`
- I added libs to be linked into the final binary by editing `binding.gyp`, and use same libs as for linux
- I added and install step for `setuptools`, as I got error due to missing `distutils` on `npm i`

Windows builds failed, but I guess fixes are already on `main`, we should rebase to `main` if this PR is accepted (To keep changes readable)