### PR TITLE
Windows: fix build by adding NODEFAULTLIB:LIBCMT

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -23,6 +23,11 @@
         ],
       }],
       ['OS=="win"', {
+        'msvs_settings': {
+          'VCLinkerTool': {
+            'AdditionalOptions': [ '/NODEFAULTLIB:LIBCMT' ],
+          },
+        },
         "libraries": [
           "<(module_root_dir)/deps/transmission/build/libtransmission/Release/transmission.lib",
           "<(module_root_dir)/deps/transmission/build/third-party/dht.bld/pfx/lib/dht.lib",


### PR DESCRIPTION
Not sure why this was working before, I had remove these lines in https://github.com/G-Ray/transmission-native/commit/d126038b5064022797bde61fcb63056541ac6136