### PR TITLE
Support rebuild

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,38 +15,36 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Cache vcpkg
-      uses: actions/cache@v3
-      env:
-        # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#environment-variables
-        VCPKG_INSTALLATION_ROOT: C:\vcpkg
-        cache-name: cache-vcpkg
-      with:
-        path: ${{ env.VCPKG_INSTALLATION_ROOT }}
-        key: ${{ runner.os }}-${{ env.cache-name }}
-      if: ${{ matrix.os == 'windows-latest' }}
-    - name: Install linux deps
-      run: sudo apt update && sudo apt install -y libcurl4-openssl-dev
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Cache vcpkg
+        uses: actions/cache@v3
+        env:
+          # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#environment-variables
+          VCPKG_INSTALLATION_ROOT: C:\vcpkg
+          cache-name: cache-vcpkg
+        with:
+          path: ${{ env.VCPKG_INSTALLATION_ROOT }}
+          key: ${{ runner.os }}-${{ env.cache-name }}
+        if: ${{ matrix.os == 'windows-latest' }}
+      - name: Install linux deps
+        run: sudo apt update && sudo apt install -y libcurl4-openssl-dev
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
-    - name: Install windows deps
-      run: vcpkg install curl openssl --triplet=x64-windows-static
-      if: ${{ matrix.os == 'windows-latest' }}
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18.x
-    - run: npm run fetch-deps
-    - run: npm run build-transmission
-    - run: npm i
-    - run: npm test
-    - run: npm run prebuild
-    - uses: actions/upload-artifact@v3
-      with:
-        name: ${{ matrix.os }}
-        path: ./prebuilds
+      - name: Install windows deps
+        run: vcpkg install curl openssl --triplet=x64-windows-static
+        if: ${{ matrix.os == 'windows-latest' }}
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - run: npm i
+      - run: npm test
+      - run: npm run prebuild
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}
+          path: ./prebuilds
   build-aarch64:
     # The host should always be Linux
     runs-on: ubuntu-latest
@@ -71,8 +69,6 @@ jobs:
             apt install -y nodejs
             # Build
             git config --global --add safe.directory '*'
-            npm run fetch-deps
-            npm run build-transmission
             npm i
             npm test
             npm run prebuild-arm64

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/transmission"]
-	path = deps/transmission
-	url = https://github.com/G-Ray/transmission.git

--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
   "license": "GPL-3.0",
   "main": "index.js",
   "scripts": {
-    "install": "node-gyp-build",
+    "install": "node-gyp-build \"node scripts/build-transmission.js\"",
     "test": "standard && node --test test.js",
     "prebuild": "prebuildify --napi --strip",
-    "prebuild-arm64": "prebuildify --napi --strip --arch=arm64",
-    "fetch-deps": "git submodule update --recursive --init",
-    "build-transmission": "node ./scripts/build-transmission.js"
+    "prebuild-arm64": "prebuildify --napi --strip --arch=arm64"
   },
   "dependencies": {
     "napi-macros": "^2.2.2",

--- a/scripts/build-transmission.js
+++ b/scripts/build-transmission.js
@@ -29,7 +29,8 @@ const COMMON_CMAKE_FLAGS = [
 ]
 
 const { env } = process
-const buildPath = path.join(__dirname, '../deps/transmission/build')
+const transmissionPath = path.join(__dirname, '../deps/transmission')
+const buildPath = path.join(transmissionPath, 'build')
 
 const runCommand = async (command, args = [], options = {}) => {
   return new Promise((resolve, reject) => {
@@ -39,14 +40,30 @@ const runCommand = async (command, args = [], options = {}) => {
   })
 }
 
-const cmake = (...args) => runCommand('cmake', ...args)
+// Clone transmission repo
+const clone = async () => {
+  if (fs.existsSync(transmissionPath)) return
 
-if (!fs.existsSync(buildPath)) {
-  fs.mkdirSync(buildPath)
+  await runCommand('git', [
+    'clone',
+    '-b',
+    '4.0.3-transmission-native',
+    '--recurse-submodules',
+    'https://github.com/G-Ray/transmission.git',
+    transmissionPath
+  ])
 }
+
+const cmake = (...args) => runCommand('cmake', ...args)
 
 const build = async () => {
   const osType = os.type()
+
+  await clone()
+
+  if (!fs.existsSync(buildPath)) {
+    fs.mkdirSync(buildPath)
+  }
 
   if (osType === 'Linux') {
     const flags = [


### PR DESCRIPTION
* Removed submodule in favor of cloning from `scripts/build-transmission.js`
* In `install script`, added a command to `node-gyp-build` which should run only when building from sources.
* Updated CI workflow to remove `fetch-deps` & `build-transmission`

Fixes #29 