### PR TITLE
Use self-hosted github runner for aarch64

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
   build-x64:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-22.04-aarch64, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -28,8 +28,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Install linux deps
-        run: sudo apt update && sudo apt install -y libcurl4-openssl-dev
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt update && sudo apt install -y git cmake build-essential libcurl4-openssl-dev libssl-dev
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Install windows deps
         run: vcpkg install curl openssl --triplet=x64-windows-static
@@ -41,38 +41,10 @@ jobs:
       - run: npm i
       - run: npm test
       - run: npm run prebuild
+        if: ${{ matrix.os != 'ubuntu-22.04-aarch64' }}
+      - run: npm run prebuild-arm64
+        if: ${{ matrix.os == 'ubuntu-22.04-aarch64' }}
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}
-          path: ./prebuilds
-  build-aarch64:
-    # The host should always be Linux
-    runs-on: ubuntu-latest
-    name: Build on aarch64
-    steps:
-      - uses: actions/checkout@v3
-      - uses: uraimo/run-on-arch-action@v2
-        name: Run commands
-        with:
-          arch: aarch64
-          distro: ubuntu_latest
-          run: |
-            # install deps
-            apt update
-            apt install -y libcurl4-openssl-dev git cmake build-essential libssl-dev
-            # Install nodejs
-            apt install -y ca-certificates curl gnupg
-            mkdir -p /etc/apt/keyrings
-            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-            apt update
-            apt install -y nodejs
-            # Build
-            git config --global --add safe.directory '*'
-            npm i
-            npm test
-            npm run prebuild-arm64
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ubuntu-latest
           path: ./prebuilds

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,5 +46,5 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04-aarch64' }}
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}
+          name: prebuilds
           path: ./prebuilds


### PR DESCRIPTION
By using a self-hosted aarch64 runner, we can reduce CI from 36 minutes to less than 3 minutes builds on aarch64.